### PR TITLE
Found a bug in the deadline-installer.sh script

### DIFF
--- a/Installation/Linux/install-deadline.sh
+++ b/Installation/Linux/install-deadline.sh
@@ -9,7 +9,7 @@ pushd /tmp
 
 curl -L http://www.thinkboxsoftware.com/deadline-downloads/deadline-release-5247700-june-27-2012/Deadline_Linux_Installers_`uname -i`_5_2_47700.tar | tar x
 
-DeadlineRepos*	&& rm DeadlineRepos*
-DeadlineClient*	&& rm DeadlineClient*	
+./DeadlineRepos*	&& rm DeadlineRepos*
+./DeadlineClient*	&& rm DeadlineClient*	
 
 popd


### PR DESCRIPTION
Basically, didn't remember to throw the current paths in there. How/if this worked before, I have no idea.
