### PR TITLE
typo in plist for log filepath & alternative approach to install for all...

### DIFF
--- a/Installation/Mac/Licensing/Readme.txt
+++ b/Installation/Mac/Licensing/Readme.txt
@@ -69,4 +69,19 @@ The Launch daemon writes errors to /var/log/system.log with a prefix of
 the user and group 'deadline' exist, or you edit and reload the plist to have
 a custom combo, like 'edwin.amsler' and 'wheel' like I did during testing :)
 
+Alternative Approach:
+I (MO) installed the license server files to: /Applications/Thinkbox/LicenseServer/
+
+Files:
+
+Thinkbox.log
+Thinkbox_license.lic
+frantic
+lmgrd
+lmutil
+thinkbox
+
+Setting all permissions to: chown -R root:admin as this user/group account exists by default on OSX. Then edited the plist UserName/GroupName to "daemon" as we are daemonising the lmgrd application. Upon boot-up, this will work for any user account that logs in as it's running as the default daemon user/group, which [launchd] running as root likes :-) 
+
+
 If you hit any snags using this, as usual, e-mail support@thinkboxsoftware.com

--- a/Installation/Mac/Licensing/com.thinkbox.license.plist
+++ b/Installation/Mac/Licensing/com.thinkbox.license.plist
@@ -6,21 +6,23 @@
 		<string>com.thinkbox.lmgrd</string>
 	<key>ProgramArguments</key>
 		<array>
-			<string>/usr/local/Thinkbox/lmgrd/lmgrd</string>
+			<string>/Applications/Thinkbox/LicenseServer/lmgrd</string>
 			<string>-z</string>
 			<string>-c</string>
-			<string>/usr/local/Thinkbox/lmgrd/Thinkbox_license.lic</string>
+			<string>/Applications/Thinkbox/LicenseServer/Thinkbox_license.lic</string>
+			<string>-l</string>
+			<string>/Applications/Thinkbox/LicenseServer/Thinkbox.log</string>
 		</array>
 	<key>RunAtLoad</key>
 		<true/>
 	<key>UserName</key>
-		<string>deadline</string>
+		<string>daemon</string>
 	<key>GroupName</key>
-		<string>deadline</string>
+		<string>daemon</string>
 	<key>StandardOutPath</key>
-		<string>/usr/local/Thinkbox/lmgrd/Thinkbox_license.lic</string>
+		<string>/Applications/Thinkbox/LicenseServer/Thinkbox.log</string>
 	<key>StandardErrorPath</key>
-		<string>/usr/local/Thinkbox/lmgrd/Thinkbox_license.lic</string>
+		<string>/Applications/Thinkbox/LicenseServer/Thinkbox.log</string>
 	<key>KeepAlive</key>
 		<true/>
 </dict>


### PR DESCRIPTION
... users

typo in plist for Thinkbox.log. Writing the STDout to the license file
borks out the license file!

Also, alternative approach to installing under /Applications and
executing via [launchd] as root as we are daemonising this app, so that
all users will have this working.