### PR TITLE
Make testing kinder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ python:
   - "2.7"
   - "3.4"
   
-install:
-  - "pip install pep8"
-  
 script:
-  - pep8 --filename=*.py --count --ignore=W293,E501 .
   - python -m compileall -f -q .
 

--- a/ci-test.bat
+++ b/ci-test.bat
@@ -1,0 +1,3 @@
+pep8 --filename=*.py --count --ignore=W293,E501 .
+python -m compileall -f -q .
+


### PR DESCRIPTION
* Removed requirement for PEP8 compliance sicne we don't require this internally
* Added a Windows batch file to test conformance (still needs a pause if pep8 exited badly)