### PR TITLE
Adjustments to .gitignore and PEP exclusions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,8 @@ obj
 *.pyc
 .DS_Store
 
+# Vagrant
+.vagrant
+
 # mstest test results
 TestResults

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,5 +4,5 @@ job-compile:
 
 job-pep8:
   script:
-    - pep8 --filename=*.py --count --ignore=W293,E501 .
+    - pep8 --filename=*.py --count --ignore=W293,E201,E202,E501 .
 

--- a/ci-test.bat
+++ b/ci-test.bat
@@ -1,3 +1,3 @@
-pep8 --filename=*.py --count --ignore=W293,E501 .
+pep8 --filename=*.py --count --ignore=W293,E201,E202,E501 .
 python -m compileall -f -q .
 

--- a/ci-test.sh
+++ b/ci-test.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-pep8 --filename=*.py --count --ignore=W293,E501 .
+pep8 --filename=*.py --count --ignore=W293,E201,E202,E501 .
 python -m compileall -f -q .
 


### PR DESCRIPTION
Adds ignore for .vagrant subfolder in .gitignore.

Also adds ignoring of PEP E201 and E202 which object to spaces after ( and before ).  Spaces help readability in complex code.  If spaces were not important, then why does there exist an E231 (missing white space after ',')?  Seems contradictory.  Spaces also help prevent accidental picking up of a stray paren when copying function parameters.  Pasting a stray paren invariably leads to hard-to-find bugs, since the compiler error is usually distant from the location of the extraneous paren.