### PR TITLE
Fix logic-o

### DIFF
--- a/Custom/events/AutoChunker/AutoChunker.py
+++ b/Custom/events/AutoChunker/AutoChunker.py
@@ -40,7 +40,7 @@ class AutoChunker( DeadlineEventListener ):
 		
 		# Only execute for Maya jobs.
 		jobPlugin = job.JobPlugin
-		if jobPlugin != "MayaBatch" or jobPlugin != "MayaCmd":
+		if not job.JobPlugin in ["MayaBatch", "MayaCmd"]:
 			return
 
 		# Only execute if it's a job submitted by user "dave", for say, testing purposes.


### PR DESCRIPTION
The previous if statement would always evaluate to true because of the `or` statement. Thanks to Jay Tsang for mentioning!