### PR TITLE
Allow more flexible priority clamps based on user groups

### DIFF
--- a/Custom/events/PriorityClamp/PriorityClamp.param
+++ b/Custom/events/PriorityClamp/PriorityClamp.param
@@ -5,21 +5,11 @@ Label=State
 Default=Disabled
 Description=How this event plug-in should respond to events. If Global, all jobs and slaves will trigger the events for this plugin. If Opt-In, jobs and slaves can choose to trigger the events for this plugin. If Disabled, no events are triggered for this plugin.
 
-[Priority]
-Type=Integer
+[PriorityMap]
+Type=multilinestring
 Category=Options
 CategoryOrder=0
 Index=1
-Label=Priority
-Default=50
-Description=Max Priority.
-Minimum=0
-
-[UserGroups]
-Type=String
-Category=Options
-CategoryOrder=0
-Index=2
-Default=Casual
-Label=Groups
-Description=Users Group.
+Label=Priority Mapping
+Default=admins<100;users<10
+Description=Max priority mapping for user groups. Eg: admins<100"

--- a/Custom/events/PriorityClamp/PriorityClamp.param
+++ b/Custom/events/PriorityClamp/PriorityClamp.param
@@ -12,4 +12,4 @@ CategoryOrder=0
 Index=1
 Label=Priority Mapping
 Default=admins<100;users<10
-Description=Max priority mapping for user groups. Eg: admins<100"
+Description=Max priority mapping for user groups. Eg: admins<100

--- a/Custom/events/PriorityClamp/Readme.txt
+++ b/Custom/events/PriorityClamp/Readme.txt
@@ -1,14 +1,21 @@
 What everyone's been waiting for, a way to limit users from hogging the farm.
 
-The idea is that you can prevent everyone but blessed users from a specific
-user group from submitting jobs higher than a certain priority.
+The idea is that you can prevent everyone but blessed users from specific
+user groups from submitting jobs higher than a certain priority.
 
 Copy this whole folder into '[repo]/custom/events', reload the scripts in your
 Monitor under the 'tools' menu, and go into 'Configure Plugins' to set up what
 user group you'd like to bless with allowing submissions higher than the
 maximum (also settable).
 
-For those unfamiliar with user groups, check out the 7.0 documetation on the
+You'll want to map them like so:
+group<priority
+
+For example, for regular users, you can prevent them from submitting jobs higher
+than 50 with the following line:
+everyone<50
+
+For those unfamiliar with user groups, check out the 7.0 documentation on the
 subject:
 http://docs.thinkboxsoftware.com/products/deadline/7.0/1_User%20Manual/manual/user-management.html#managing-user-groups
 


### PR DESCRIPTION
I was asked to provide a solution to clamp priorities for multiple user groups. This adds that ability.