### PR TITLE
Track Project Id for all Deadline job names

### DIFF
--- a/Custom/events/TrackProjectId/README.rst
+++ b/Custom/events/TrackProjectId/README.rst
@@ -1,0 +1,4 @@
+TrackProjectId.py
+==================================
+
+This example event plugin script hooks into the "OnJobSubmitted" callback and allows a studio to globally extract the first 5 characters for each submitted job's job name and add it to the first Extra Info column known as: "Extra Info 0 "; which can be renamed to something logical for studio specific display purposes and also to allow a customer to generate a report/graph against later completed Deadline jobs via the Deadline Stats module.

--- a/Custom/events/TrackProjectId/TrackProjectId.param
+++ b/Custom/events/TrackProjectId/TrackProjectId.param
@@ -1,0 +1,6 @@
+[State]
+Type=Enum
+Items=Global Enabled;Opt-In;Disabled
+Label=State
+Default=Global Enabled
+Description=How this event plug-in should respond to events. If Global, all jobs and slaves will trigger the events for this plugin. If Opt-In, jobs and slaves can choose to trigger the events for this plugin. If Disabled, no events are triggered for this plugin.

--- a/Custom/events/TrackProjectId/TrackProjectId.py
+++ b/Custom/events/TrackProjectId/TrackProjectId.py
@@ -1,0 +1,39 @@
+###############################################################
+# Imports
+###############################################################
+from __future__ import print_function
+from System import *
+
+from Deadline.Events import *
+from Deadline.Scripting import *
+
+##################################################################################################
+# This is the function called by Deadline to get an instance of the TrackProjectId event listener.
+##################################################################################################
+def GetDeadlineEventListener():
+    return TrackProjectIdListener()
+
+def CleanupDeadlineEventListener(eventListener):
+    eventListener.Cleanup()
+
+###############################################################
+# The event listener class.
+###############################################################
+class TrackProjectIdListener (DeadlineEventListener):
+    def __init__(self):
+        self.OnJobSubmittedCallback += self.OnJobSubmitted
+    
+    def Cleanup(self):
+        del self.OnJobSubmittedCallback
+
+    def OnJobSubmitted(self, job):
+
+        # Exit this event plugin as soon as possible if job name length is less than valid 5 characters
+        if len(job.JobName) < 5:
+            return
+        
+        projectId = job.JobName[0:5]
+        print( "Submitted DL job for Project Id: {}".format(projectId) )
+        
+        job.JobExtraInfo0 = projectId
+        RepositoryUtils.SaveJob(job)


### PR DESCRIPTION
This example event plugin script hooks into the "OnJobSubmitted" callback and allows a studio to globally extract the first 5 characters for each submitted job's job name and add it to the first Extra Info column known as: "Extra Info 0 "; which can be renamed to something logical for studio specific display purposes and also to allow a customer to generate a report/graph against later completed Deadline jobs via the Deadline Stats module.