### PR TITLE
Updated the event scripts to run with Deadline 10.3 

### DIFF
--- a/Custom/events/AutomaticPreviewJobSubmission/AutomaticPreviewJobSubmission.param
+++ b/Custom/events/AutomaticPreviewJobSubmission/AutomaticPreviewJobSubmission.param
@@ -3,4 +3,4 @@ Type=Enum
 Items=Global Enabled;Opt-In;Disabled
 Label=State
 Default=Disabled
-Description=How this event plug-in should respond to events. If Global, all jobs and Slaves will trigger the events for this plugin. If Opt-In, jobs and Slaves can choose to trigger the events for this plugin. If Disabled, no events are triggered for this plugin.
+Description=How this event plug-in should respond to events. If Global, all jobs and Workers will trigger the events for this plugin. If Opt-In, jobs and Workers can choose to trigger the events for this plugin. If Disabled, no events are triggered for this plugin.

--- a/Custom/events/AutomaticPreviewJobSubmission/AutomaticPreviewJobSubmission.py
+++ b/Custom/events/AutomaticPreviewJobSubmission/AutomaticPreviewJobSubmission.py
@@ -1,5 +1,7 @@
-from Deadline.Events import *
-from Deadline.Scripting import *
+from Deadline.Events import DeadlineEventListener
+from Deadline.Scripting import RepositoryUtils
+
+import sys
 
 ##################################################################################
 ## This is the function that Deadline calls to get an instance of the
@@ -25,6 +27,8 @@ def CleanupDeadlineEventListener( deadlinePlugin ):
 class AutomaticPreviewJobSubmissionListener (DeadlineEventListener):
 
     def __init__( self ):
+        if sys.version_info.major == 3:
+            super().__init__()
         # Set up the event callbacks here
         self.OnJobSubmittedCallback += self.OnJobSubmitted
 
@@ -36,7 +40,7 @@ class AutomaticPreviewJobSubmissionListener (DeadlineEventListener):
 
         # Resume first, middle, and last tasks
         tasks = list(RepositoryUtils.GetJobTasks( job, True ).TaskCollectionAllTasks)
-        middleIndex = (len(tasks) - 1)/2
+        middleIndex = int((len(tasks) - 1)/2)
         RepositoryUtils.ResumeTasks(job, [tasks[0], tasks[middleIndex], tasks[-1]])
 
         self.LogInfo("On Job Submitted Event Plugin: AutomaticPreviewJobSubmission finished")

--- a/Custom/events/AutomaticPreviewJobSubmission/README.md
+++ b/Custom/events/AutomaticPreviewJobSubmission/README.md
@@ -22,7 +22,7 @@ So if you want to adapt this for your own usecase, you should supply some more s
 
 ## Usage Instructions
 
-This [page of our documentation](https://docs.thinkboxsoftware.com/products/deadline/10.0/1_User%20Manual/manual/event-plugins.html#creating-an-event-plug-in) provides a more in-depth look at how to create a custom Event Plugin.
+This [page of our documentation](https://docs.thinkboxsoftware.com/products/deadline/10.3/1_User%20Manual/manual/event-plugins.html#creating-an-event-plug-in) provides a more in-depth look at how to create a custom Event Plugin.
 
 But to "plug-and-play" with this example plugin, all you need to do is:
 * Copy the `AutomaticPreviewJobSubmission` folder from this repository to the `custom/events` folder under your DeadlineRepository path.

--- a/Custom/events/PriorityClamp/PriorityClamp.param
+++ b/Custom/events/PriorityClamp/PriorityClamp.param
@@ -3,7 +3,7 @@ Type=Enum
 Items=Global Enabled;Opt-In;Disabled
 Label=State
 Default=Disabled
-Description=How this event plug-in should respond to events. If Global, all jobs and slaves will trigger the events for this plugin. If Opt-In, jobs and slaves can choose to trigger the events for this plugin. If Disabled, no events are triggered for this plugin.
+Description=How this event plug-in should respond to events. If Global, all jobs and Workers will trigger the events for this plugin. If Opt-In, jobs and Workers can choose to trigger the events for this plugin. If Disabled, no events are triggered for this plugin.
 
 [PriorityMap]
 Type=multilinestring

--- a/Custom/events/PriorityClamp/PriorityClamp.py
+++ b/Custom/events/PriorityClamp/PriorityClamp.py
@@ -5,8 +5,8 @@ from System.Diagnostics import *
 from System.IO import *
 from System import TimeSpan
 
-from Deadline.Events import *
-from Deadline.Scripting import *
+from Deadline.Events import DeadlineEventListener
+from Deadline.Scripting import RepositoryUtils
 
 import re
 import sys
@@ -29,6 +29,8 @@ def CleanupDeadlineEventListener(eventListener):
 ###############################################################
 class JobEventListener (DeadlineEventListener):
     def __init__(self):
+        if sys.version_info.major == 3:
+            super().__init__()    
         self.OnJobSubmittedCallback += self.OnJobSubmitted
 
     def Cleanup(self):

--- a/Custom/events/PriorityClamp/Readme.txt
+++ b/Custom/events/PriorityClamp/Readme.txt
@@ -15,7 +15,7 @@ For example, for regular users, you can prevent them from submitting jobs higher
 than 50 with the following line:
 everyone<50
 
-For those unfamiliar with user groups, check out the 7.0 documentation on the
+For those unfamiliar with user groups, check out the documentation on the
 subject:
 https://docs.thinkboxsoftware.com/products/deadline/10.3/1_User%20Manual/manual/user-management.html#managing-user-groups
 

--- a/Custom/events/PriorityClamp/Readme.txt
+++ b/Custom/events/PriorityClamp/Readme.txt
@@ -17,7 +17,7 @@ everyone<50
 
 For those unfamiliar with user groups, check out the 7.0 documentation on the
 subject:
-http://docs.thinkboxsoftware.com/products/deadline/7.0/1_User%20Manual/manual/user-management.html#managing-user-groups
+https://docs.thinkboxsoftware.com/products/deadline/10.3/1_User%20Manual/manual/user-management.html#managing-user-groups
 
 If there are problems or if you'd like us to change something e-mail
 the support team at support@thinkboxsoftware.com

--- a/Custom/events/SetJobTimeout/SetJobTimeout.param
+++ b/Custom/events/SetJobTimeout/SetJobTimeout.param
@@ -3,7 +3,7 @@ Type=Enum
 Items=Global Enabled;Opt-In;Disabled
 Label=State
 Default=Disabled
-Description=How this event plug-in should respond to events. If Global, all jobs and slaves will trigger the events for this plugin. If Opt-In, jobs and slaves can choose to trigger the events for this plugin. If Disabled, no events are triggered for this plugin.
+Description=How this event plug-in should respond to events. If Global, all jobs and Workers will trigger the events for this plugin. If Opt-In, jobs and Workers can choose to trigger the events for this plugin. If Disabled, no events are triggered for this plugin.
 
 [MaxMinute]
 Type=integer

--- a/Custom/events/SetJobTimeout/SetJobTimeout.py
+++ b/Custom/events/SetJobTimeout/SetJobTimeout.py
@@ -1,9 +1,10 @@
 ###############################################################
 # Imports
 ###############################################################
-from Deadline.Events import *
-from Deadline.Scripting import *
+from Deadline.Events import DeadlineEventListener
+from Deadline.Scripting import RepositoryUtils
 
+import sys
 
 def GetDeadlineEventListener():
     return SetJobTimeout()
@@ -18,6 +19,8 @@ def CleanupDeadlineEventListener(eventListener):
 ###############################################################
 class SetJobTimeout(DeadlineEventListener):
     def __init__(self):
+        if sys.version_info.major == 3:
+            super().__init__()
         self.OnJobSubmittedCallback += self.OnJobSubmitted
     
     def Cleanup(self):


### PR DESCRIPTION
*Issue #, if available:*
The script was outdated and would not work with latest Deadline 10.3. Also, there were couple callout for Slaves (Now called Workers)

*Description of changes:*
* Updated the script to run with Deadline 10.3
* Replaced Slave with Worker call out

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
